### PR TITLE
fix dismiss IllegalArgumentException

### DIFF
--- a/src/com/marakana/android/yamba/StatusFragment.java
+++ b/src/com/marakana/android/yamba/StatusFragment.java
@@ -180,7 +180,9 @@ public class StatusFragment extends Fragment {
 		// Called after doInBackground() on UI thread
 		@Override
 		protected void onPostExecute(String result) {
-			progress.dismiss();
+			if(isResumed()) {
+				progress.dismiss();
+			}
 			if (getActivity() != null && result != null)
 				Toast.makeText(getActivity(), result, Toast.LENGTH_LONG).show();
 		}


### PR DESCRIPTION
Hi I am with the University of Colorado programming languages and verification group. We are working on methods to automatically detect hard to find defects in Android applications. I recently found this crash with the tools I am developing for my research and created this patch.

To reproduce:
--------------
* You should be able to use any device, however I tested on the emulator and my Samsung galaxy s7
* Click the + icon at the top of the screen
* Press "Tweet"
* Quickly rotate the phone
* Application will crash with an IllegalArgumentException if the timing right
* To make the crash easier to observe in testing, delay the doInBackground method of ExportTrackTask by half a second, however this is not necessary as a slow SD card or network connection could cause this.
```
@Override
protected String doInBackground(String... params) {
try {
         Thread.sleep(500);
} catch (InterruptedException e) {
          e.printStackTrace();
}
```

Stack Trace/ ADB logcat
------------------------
```
03-17 19:04:50.168 2612-2612/com.marakana.android.yamba E/AndroidRuntime: FATAL EXCEPTION: main
                                                                          Process: com.marakana.android.yamba, PID: 2612
                                                                          java.lang.IllegalArgumentException: View=DecorView@ce14a[Posting] not attached to window manager
                                                                              at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:473)
                                                                              at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:382)
                                                                              at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:128)
                                                                              at android.app.Dialog.dismissDialog(Dialog.java:727)
                                                                              at android.app.Dialog.dismiss(Dialog.java:710)
                                                                              at com.marakana.android.yamba.StatusFragment$PostTask.onPostExecute(StatusFragment.java:183)
                                                                              at com.marakana.android.yamba.StatusFragment$PostTask.onPostExecute(StatusFragment.java:134)
                                                                              at android.os.AsyncTask.finish(AsyncTask.java:660)
                                                                              at android.os.AsyncTask.-wrap1(AsyncTask.java)
                                                                              at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:677)
                                                                              at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                              at android.os.Looper.loop(Looper.java:154)
                                                                              at android.app.ActivityThread.main(ActivityThread.java:6642)
                                                                              at java.lang.reflect.Method.invoke(Native Method)
                                                                              at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1468)
                                                                              at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1358)

```


Fix
---

The most straightforward thing I could think to do was to check if the fragment was resumed before dismissing.  I would be interested to hear your opinion on this though.